### PR TITLE
Avoid clashing with i3-wm over /etc/i3/config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,9 @@ Homepage: https://i3wm.org/
 Package: regolith-i3-wm
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, regolith-conky-config, rofi, gnome-screensaver, compton, feh, unclutter-xfixes
-Provides: x-window-manager
+Provides: x-window-manager, i3-wm
+Replaces: i3-wm
+Conflicts: i3-wm
 Recommends: xfonts-base, fonts-dejavu-core, libanyevent-i3-perl (>= 0.12), libjson-xs-perl, rxvt-unicode | x-terminal-emulator
 Description: improved dynamic tiling window manager
  Key features of i3 are good documentation, reasonable defaults (changeable in


### PR DESCRIPTION
I was using Xubuntu 19.04 with i3 as WM before and wanted to try out Regolith by using the unstable repo as suggested in https://github.com/regolith-linux/regolith-desktop/issues/5.

Installing regolith-desktop lead to the following error:
```
dpkg: Fehler beim Bearbeiten des Archivs /tmp/apt-dpkg-install-QY8wHj/076-regolith-i3-wm_4.16-1ubuntu10_amd64.deb (--unpack):
 Versuch, »/etc/i3/config« zu überschreiben, welches auch in Paket i3-wm 4.16.1-1 ist
dpkg-deb: Fehler: »einfügen«-Unterprozess wurde durch Signal (Datenübergabe unterbrochen (broken pipe)) getötet
```
Basically i3-wm and regolith-i3-wm are trying to manage the same file (`/etc/i3/config`).

So I added some package dependencies to avoid this clash.
