### PR TITLE
Fixes i3 bar icons by including FontAwesome

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+regolith-i3 (4.16-1ubuntu17) bionic; urgency=medium
+
+  * https://github.com/regolith-linux/regolith-i3blocks/issues/1: 
+    Includes FontAwesome to fix malformed i3 bar icons
+
+ -- J "Gene" Hackman <hello@preciouschicken.com>  Mon, 17 Jun 2019 16:12:55 +0100
+
 regolith-i3 (4.16-1ubuntu16) bionic; urgency=medium
 
   * https://github.com/regolith-linux/regolith-desktop/issues/25: 

--- a/debian/patches/bar-font-fix.patch
+++ b/debian/patches/bar-font-fix.patch
@@ -1,0 +1,13 @@
+Index: git/etc/config
+===================================================================
+--- git.orig/etc/config
++++ git/etc/config
+@@ -223,7 +223,7 @@ focus_follows_mouse no
+ 
+ # Configure the bar
+ bar {
+-  font pango:Source Code Pro Medium 13
++  font pango:Source Code Pro Medium 13, FontAwesome 13
+   separator_symbol " "
+   status_command i3blocks
+   tray_output none

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@ regolith-gaps-interactive.patch
 start-unclutter-xfixes.patch
 i3bar-pango-color.patch
 feh-fix.patch
+bar-font-fix.patch


### PR DESCRIPTION
Fixes regolith-linux/regolith-i3blocks#1

Icons used in i3 bar (e.g. cog, calendar) fail to display if FontAwesome not specifically listed.  This bug not apparent in all circumstances, e.g. clean install of Ubuntu.

Unsure why there are two files containing this config detail, but thought safest is to update both?