### PR TITLE
Fixes the cursor after triggering the conky toggle

### DIFF
--- a/debian/patches/conky-keybindings.patch
+++ b/debian/patches/conky-keybindings.patch
@@ -5,7 +5,7 @@
  bindsym $mod+l layout toggle split
  
 +# show/hide keybindings
-+bindsym $mod+question exec /usr/bin/conky-toggle.sh
++bindsym $mod+question exec --no-startup-id /usr/bin/conky-toggle.sh
 +
  # toggle tiling / floating
  bindsym $mod+Shift+f floating toggle

--- a/debian/patches/i3bar-pango-color.patch
+++ b/debian/patches/i3bar-pango-color.patch
@@ -115,7 +115,7 @@
 -
  # show/hide keybindings
 -bindsym $mod+question exec /usr/bin/conky-toggle.sh
-+bindsym $mod+Shift+question exec /usr/bin/conky-toggle.sh
++bindsym $mod+Shift+question exec --no-startup-id /usr/bin/conky-toggle.sh
  
  # toggle tiling / floating
  bindsym $mod+Shift+f floating toggle


### PR DESCRIPTION
Added `--no-startup-id` to the two places I could find the conky line.

Adding it manually to `~/.config/i3-regolith/config` worked for me.